### PR TITLE
Add French translation in `README_fr.md`

### DIFF
--- a/README_fr.md
+++ b/README_fr.md
@@ -1,0 +1,102 @@
+# Les travailleurs de Microsoft et GitHub soutiennent le mouvement 996.ICU
+
+Les travailleurs chinois des technologies de l'information ont lancé un dépôt GitHub nommé [996.ICU](https://github.com/996icu/996.ICU), en référence aux horaires épuisants mis en place de manière illégale par de nombreuses sociétés chinoises - au travail de 9h du matin à 9h du soir, 6 jours par semaine. "En se soumettant au rythme '996', vous risquez de finir en soins intensifs (ICU)", ainsi que le dit le manifeste du projet. Celui-ci appelle ces entreprises high-tech à respecter le code du travail chinois ainsi que les conventions internationales du travail.
+
+Cette initiative a connu un soutien massif en Chine. Les utilisateurs de GitHub ont montré leur soutien en ajoutant des _stars_ au dépôt: en à peine quelques mois, le projet a été soutenu par plus de 200 000 personnes, le classant parmi les dépôts à la croissance la plus rapide de l'histoire de la plateforme.
+
+GitHub, détenu par Microsoft, est un service en ligne utilisé par les développeurs pour partager leur code et collaborer sur des projets logiciels. Chose importante pour le mouvement 996.ICU, GitHub est librement accessible depuis la Chine. Il s'agit de la plateforme principalement utilisée par les développeurs chinois, constituant par là même une composante essentielle au fonctionnement des entreprises chinoises des technologies de l'information. Avec la prise d'importance du mouvement, les navigateurs domestiques chinois tels ceux de Tencent ou d'Alibaba ont restreint l'accès au dépôt 996.ICU, sous prétexte qu'il contiendrait des contenus malveillants, voire illégaux. Nous devons nous préparer à l'éventualité que Microsoft et GitHub subissent des pressions pour supprimer le dépôt lui-même.
+
+En réponse à ces évènements, nous, travailleurs de Microsoft et de GitHub, proclamons notre soutien au mouvement 996.ICU, et exprimons notre solidarité avec les développeurs de Chine. Nous avons conscience que ce problème dépasse les simples frontières; ces mêmes questions se posent parmi les employés à plein temps chez Microsoft, mais aussi dans le secteur des nouvelles technologies tout entier. Nous manifestons également notre solidarité avec les travailleurs chinois car l'histoire nous rappelle que les multinationales n'hésitent pas à mettre en concurrence les travailleurs dans un nivellement par le bas à base de délocalisations et de détérioration des conditions de travail dans le but de maximiser leurs profits. Nous devons nous unir à travers le monde pour assurer à tous de justes conditions de travail.
+
+Signé,
+
+__50 travailleurs des nouvelles technologies__
+
+Nous exhortons tous les travailleurs du secteur à nous rejoindre dans notre soutien au mouvement 996.ICU.
+
+Pour ajouter votre signature, créez une *pull request* contenant nom et affiliation tels que vous souhaitez qu'ils apparaissent dans la liste des signataires. Vous pouvez aussi envoyer un courriel à <msworkers4good@protonmail.com> avec ces mêmes informations afin d'être ajouté à la liste. Plus d'informations sont disponibles [à la page suivante (en anglais)](CONTRIBUTING.md).
+
+> \* Nous avons publié cette tribune le jour de son annonce au sein de Microsoft. Le nombre de signataires sera mis à jour périodiquement avec l'ajout de nouvelles signatures.
+
+Avec le soutien de:
+---
+
+> Les noms des 50 premiers signataires ont été classés au hasard.
+
+* Jason Prado, Ex-Microsoft Software Engineer 2008-2009
+* Zora Tung, Software Engineer, Google
+* Liz O’Sullivan, former head of annotations at Clarifai
+* Jing Jing Cao, UX Designer, Anki
+* Ali Atasever, CTO, Vivoo
+* Amr Gaber, Software Engineer, Google
+* Irene Knapp, Senior Software Engineer, Google
+* Harshita Gupta, Student, Harvard University and former Software Engineering Intern (x2), Microsoft
+* Alex Goldschmidt, Software Engineer, Microsoft
+* JS Tan, Software Engineer, Microsoft
+* Mark Dudley, Software Engineer, Google
+* Rachel Miller, Writer
+* Meredith Whittaker, AI Now Institute Co-founder, NYU Distinguished Research Scientist, Google Open Research Founder
+* Hal Daumé III, Principal Researcher, Microsoft Research
+* Casey Hong, Microsoft
+* Ben Tarnoff, Logic Editor
+* François Conil, Support, GitHub
+* Esteban Roncancio, Trip Advisor
+* Mark Seaborn, Software Engineer Google
+* Josh McDuffie, Software Engineer, Constant Contact
+* Ashly Hamilton, Program Manager, Microsoft
+* Emily Cunningham, UX Designer at Amazon
+* Andrew Schwartzmeyer, Software Engineer, Microsoft
+* Sergey Alekhnovich, Software Engineer, iFood Decision Sciences
+* Topher Weiss, Software Developer, Rational Interaction @ Microsoft
+* Alexander Mancevice, Software Developer, CargoMetrics
+* Cathy Lee, Brand designer, Oscar Health
+* Yann Achard, Senior Software Engineer, Microsoft
+* Camille Malonzo, Software Engineer Microsoft
+* Kelly Wagman, Microsoft Research Assistant
+* Mary L. Gray Senior Researcher Microsoft Research New England  (Associate Professor School of Informatics, Computing, and Engineering Indiana University, Bloomington | Fellow Harvard University Berkman Klein Center for Internet and Society)
+* Francis Tseng, Public Science
+* Esteban Roncancio, Software Engineer, TripAdvisor
+* Naomi Harrington, Program Manager, Microsoft
+* Mikayla Hutchinson, Software Engineer, Microsoft
+* David Meyerson, Software Engineer II, Microsoft
+* Bryan Hughes, Senior Cloud Advocate, Microsoft
+* Christopher Senderling, Microsoft
+* Gregory Ellison, Data Scientist, Microsoft
+* Stephanie Parker, Policy Specialist, YouTube
+* Adina Shanholtz, Microsoft
+* Marie Collins, Business Analyst, Google
+* Kristen Sheets, Brandeis University Computer Science
+* Erik Knechtel, Microsoft Contractor
+* Daniel Greene, Assistant Professor of Information Studies, University of Maryland
+* Amber Erickson, Software Engineer, Microsoft
+* Julie Mayer, Senior Privacy Manager, Microsoft
+* Minsoo Thigpen, Microsoft Program Manager
+* Lowell Bander, Software Engineer, Facebook
+* Wendy Liu, Tech Writer
+* Nisha Pillai, Software Engineer
+* DeepGrace, Senior C++ Expert
+* Liu Jun, Software Engineer, Guangbao-uni
+* Xeodou Li, Software Engineer, Udacity
+* Sangyu Li, Former MSDN Editor,Editor at Hubei Commitee of CCYL,Staff of Wuhan Railway Bureau
+* Ranjan Pradeep, Software Engineer, Microsoft
+* Lion Huang, Senior Software Engineer, Microsoft
+* Yinghao Liu, Senior Software Engineer, ThoughtWorks
+* Dong Jin Zhao, Software Engineer
+* Lin Zhang, Software Engineer II, Microsoft
+* Liang Ding, Full-Time Open-Sourcerer, B3log
+* Benson Laur, Software Engineer, Guangzhou Wangshi Software Technology Co. Ltd.
+* Nekocode(Fan Yueng), Software Engineer, Freelancer
+* JackEggie(Jack Tang), Software Engineer, Infor
+* ZiHang Gao, Software Engineer, IReader
+* Phodal(Fengda Huang), Senior Software Engineer, ThoughtWorks
+* Zhida Liu, Software Engineer, Enjoylife
+* Hancel Lin, Software Engineer, GIGABYTE.
+* Zhongyu Hwang, Android Software Engineer, Chongqing Genesis Network Technology Co.,Ltd
+* Knove, Software Engineer, Xiaomi
+* Lip Young(杨 征), Fontend Software Coder, Freelancer
+* Txdy, Software Engineer, Guangzhou Wangshi Software Technology Co. Ltd.
+* Yuchong Pan, Software Engineering Intern (x2), Microsoft, & Student, University of British Columbia
+* Margox(Wang Gang), Software Engineer
+* Yibo Wei, Mobile Developer, SAP
+* Cherrie Yu Cheng, Product Manager
+* Zion Chen, Software Engineer, SAP


### PR DESCRIPTION
Hi !

I am a native French speaker, with a [C2 Proficiency](https://en.wikipedia.org/wiki/C2_Proficiency) certification in English. I didn't translate the affiliation names since 1) they would not make a lot of sense in French and 2) the list would be harder to maintain. Other than that the translation is quite close to the original with some changes to improve the overall flow of the French version.