### PR TITLE
首届996优秀项目大赛邀请函

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 [![LICENSE](https://img.shields.io/badge/license-Anti%20996-blue.svg)](https://github.com/996icu/996.ICU/blob/master/LICENSE)
 <a href="https://996.icu"><img src="https://img.shields.io/badge/link-996.icu-red.svg" alt="996.icu"></a>
 
+[![top.996](https://img.shields.io/badge/link-top.996-red.svg)](https://github.com/top996/top.996)
 
 Tech workers in China started a GitHub repository titled [996.ICU](https://github.com/996icu/996.ICU), a reference to the grueling and illegal working hours of many tech companies in China - from 9am to 9pm, 6 days a week. "By following the '996' work schedule, you are risking yourself getting into the ICU (Intensive Care Unit)," says the 996.ICU GitHub project description. The project calls for Chinese tech companies to obey the labor laws in China and the international labor convention.
 


### PR DESCRIPTION
首届996优秀项目大赛，投票截止日期为2019年7月1日，7月10日公布最终比赛结果。 大赛选取了目前github上各个反996热门项目，大赛前三名将获得对应的项目发展支持基金。 一等奖人民币5000元，二等奖人民币3000元，三等奖人民币1000元，四到六名纪念奖人民币300元。
[站长请加微信群](https://github.com/top996/top.996)